### PR TITLE
Support PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.3",
+        "phpunit/phpunit": "^8.0|^9.3",
         "php-http/client-integration-tests": "^3.0"
     },
     "provide": {

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 | ^8.0",
         "php-http/httplug": "^2.0",
         "psr/http-client": "^1.0",
         "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.4",
-        "php-http/client-integration-tests": "^2.0"
+        "phpunit/phpunit": "^9.3",
+        "php-http/client-integration-tests": "^3.0"
     },
     "provide": {
         "php-http/client-implementation": "1.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="vendor/autoload.php">
-    <testsuites>
-        <testsuite name="Guzzle 7 HTTP Adapter Test Suite">
-            <directory>tests/</directory>
-        </testsuite>
-    </testsuites>
-    <php>
-        <server name="TEST_SERVER" value="http://127.0.0.1:10000/server.php" />
-    </php>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    colors="true"
+    bootstrap="vendor/autoload.php"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Guzzle 7 HTTP Adapter Test Suite">
+      <directory>tests/</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <server name="TEST_SERVER" value="http://127.0.0.1:10000/server.php"/>
+  </php>
 </phpunit>

--- a/tests/DefaultHttpAdapterTest.php
+++ b/tests/DefaultHttpAdapterTest.php
@@ -6,6 +6,7 @@ namespace Http\Adapter\Guzzle7\Tests;
 
 use Http\Adapter\Guzzle7\Client;
 use Http\Client\Tests\HttpClientTest;
+use Psr\Http\Client\ClientInterface;
 
 /**
  * @author David Buchmann <mail@davidbu.ch>
@@ -15,7 +16,7 @@ class DefaultHttpAdapterTest extends HttpClientTest
     /**
      * {@inheritdoc}
      */
-    protected function createHttpAdapter()
+    protected function createHttpAdapter(): ClientInterface
     {
         return new Client();
     }

--- a/tests/HttpAdapterTest.php
+++ b/tests/HttpAdapterTest.php
@@ -7,6 +7,7 @@ namespace Http\Adapter\Guzzle7\Tests;
 use GuzzleHttp\Client as GuzzleClient;
 use Http\Adapter\Guzzle7\Client;
 use Http\Client\Tests\HttpClientTest;
+use Psr\Http\Client\ClientInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -16,7 +17,7 @@ abstract class HttpAdapterTest extends HttpClientTest
     /**
      * {@inheritdoc}
      */
-    protected function createHttpAdapter()
+    protected function createHttpAdapter(): ClientInterface
     {
         return new Client(new GuzzleClient(['handler' => $this->createHandler()]));
     }

--- a/tests/HttpAsyncAdapterTest.php
+++ b/tests/HttpAsyncAdapterTest.php
@@ -6,6 +6,7 @@ namespace Http\Adapter\Guzzle7\Tests;
 
 use GuzzleHttp\Client as GuzzleClient;
 use Http\Adapter\Guzzle7\Client;
+use Http\Client\HttpAsyncClient;
 use Http\Client\Tests\HttpAsyncClientTest;
 
 /**
@@ -16,7 +17,7 @@ abstract class HttpAsyncAdapterTest extends HttpAsyncClientTest
     /**
      * {@inheritdoc}
      */
-    protected function createHttpAsyncClient()
+    protected function createHttpAsyncClient(): HttpAsyncClient
     {
         return new Client(new GuzzleClient(['handler' => $this->createHandler()]));
     }

--- a/tests/PromiseExceptionTest.php
+++ b/tests/PromiseExceptionTest.php
@@ -28,7 +28,7 @@ final class PromiseExceptionTest extends TestCase
         RequestInterface $request,
         $reason,
         string $adapterExceptionClass
-    ) {
+    ): void {
         $guzzlePromise = new \GuzzleHttp\Promise\Promise();
         $guzzlePromise->reject($reason);
         $promise = new Promise($guzzlePromise, $request);

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -4,22 +4,23 @@ declare(strict_types=1);
 
 namespace Http\Adapter\Guzzle7\Tests;
 
+use Exception;
 use GuzzleHttp\Promise\RejectedPromise;
 use Http\Adapter\Guzzle7\Promise;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  */
 class PromiseTest extends TestCase
 {
-    /**
-     * @expectedException \Exception
-     */
-    public function testNonDomainExceptionIsHandled()
+    public function testNonDomainExceptionIsHandled(): void
     {
-        $request = $this->prophesize('Psr\Http\Message\RequestInterface');
-        $promise = new RejectedPromise(new \Exception());
+        $this->expectException(Exception::class);
+
+        $request = $this->prophesize(RequestInterface::class);
+        $promise = new RejectedPromise(new Exception());
 
         $guzzlePromise = new Promise($promise, $request->reveal());
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes, currently drops php7.2, will check other phpunit version 
| Deprecations?   | no
| License         | MIT


#### What's in this PR?
This PR provides the possibility to use PHP8 in projects which uses this library as a dependency.

**Required dev-dependency changes:**
 - upgrade php-http/client-integration-tests 2.0 -> 3.0
 - upgrade phpunit 7.4 -> 9.4 (+ migrated phpunit.xml with "--migrate-configuration")


#### Checklist
- [ ] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix
- [ ] Documentation pull request created (if not simply a bugfix)


#### To Do
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
