### PR TITLE
Fix the branch alias for dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.2.x-dev"
+            "dev-master": "1.x-dev"
         }
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | n/a
| Documentation   | n/a
| License         | MIT


#### What's in this PR?

the branch-alias is updated to `1.x-dev`

#### Why?

The 1.0 release was done, so dev-master is not a dev branch for 0.2.x anymore. Using `1.x-dev` rather than `1.1.x-dev` avoids having to update it after each minor version.
