### PR TITLE
Add PHP 8.4 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        php: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
       - name: Set up PHP


### PR DESCRIPTION
@dbu Could you please merge this, and then tag a new release?

I need https://github.com/php-http/guzzle7-adapter/commit/c6975e5dae550cedfb8a5c1b801f3b27aadca2a5 to be able to run this on PHP 8.4

> PHP Deprecated:  Http\Adapter\Guzzle7\Promise::then(): Implicitly marking parameter $onFulfilled as nullable is deprecated, the explicit nullable type must be used instead in vendor/php-http/guzzle7-adapter/src/Promise.php on line 76
